### PR TITLE
Add intercession selection flag to RoomState

### DIFF
--- a/src/store/gameStore.backup.ts
+++ b/src/store/gameStore.backup.ts
@@ -16,6 +16,7 @@ interface RoomState {
   connectionStatus: 'disconnected' | 'connecting' | 'connected' | 'error';
   error: string | null;
   isSoloMode: boolean;
+  intercessionSelectionStarted: boolean;
 }
 
 // UI state for multiplayer
@@ -117,6 +118,7 @@ const initialRoomState: RoomState = {
   connectionStatus: 'disconnected',
   error: null,
   isSoloMode: false,
+  intercessionSelectionStarted: false,
 };
 
 const initialUIState: UIState = {
@@ -162,6 +164,7 @@ export const useGameStore = create<GameStore>((set, get) => {
         playerId: currentPlayer?.id || null,
         isHost: true,
         uiPhase: 'LOBBY',
+        intercessionSelectionStarted: data.room.intercessionSelectionStarted ?? false,
         roomPlayers: data.room.players.map((p: any) => ({
           id: p.id,
           name: p.name,
@@ -182,6 +185,7 @@ export const useGameStore = create<GameStore>((set, get) => {
         playerId: currentPlayer?.id || null,
         isHost: false,
         uiPhase: 'LOBBY',
+        intercessionSelectionStarted: data.room.intercessionSelectionStarted ?? false,
         roomPlayers: data.room.players.map((p: any) => ({
           id: p.id,
           name: p.name,
@@ -195,6 +199,7 @@ export const useGameStore = create<GameStore>((set, get) => {
 
   socket.on('room-updated', (room: any) => {
     set({
+      intercessionSelectionStarted: room.intercessionSelectionStarted ?? false,
       roomPlayers: room.players.map((p: any) => ({
         id: p.id,
         name: p.name,

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -16,6 +16,7 @@ interface RoomState {
   connectionStatus: 'disconnected' | 'connecting' | 'connected' | 'error';
   error: string | null;
   isSoloMode: boolean;
+  intercessionSelectionStarted: boolean;
 }
 
 // UI state for multiplayer
@@ -134,6 +135,7 @@ const initialRoomState: RoomState = {
   connectionStatus: 'disconnected',
   error: null,
   isSoloMode: false,
+  intercessionSelectionStarted: false,
 };
 
 const initialUIState: UIState = {
@@ -183,6 +185,7 @@ export const useGameStore = create<GameStore>((set, get) => {
         playerId: currentPlayer?.id || null,
         isHost: true,
         uiPhase: 'LOBBY',
+        intercessionSelectionStarted: data.room.intercessionSelectionStarted ?? false,
         roomPlayers: data.room.players.map((p: any) => ({
           id: p.id,
           name: p.name,
@@ -203,6 +206,7 @@ export const useGameStore = create<GameStore>((set, get) => {
         playerId: currentPlayer?.id || null,
         isHost: false,
         uiPhase: 'LOBBY',
+        intercessionSelectionStarted: data.room.intercessionSelectionStarted ?? false,
         roomPlayers: data.room.players.map((p: any) => ({
           id: p.id,
           name: p.name,
@@ -216,6 +220,7 @@ export const useGameStore = create<GameStore>((set, get) => {
 
   socket.on('room-updated', (room: any) => {
     set({
+      intercessionSelectionStarted: room.intercessionSelectionStarted ?? false,
       roomPlayers: room.players.map((p: any) => ({
         id: p.id,
         name: p.name,


### PR DESCRIPTION
## Summary
- track whether intercession selection started in the room store
- load this flag from server responses
- reset the flag on leaving a room

## Testing
- `npm run build`
- `npm run lint` *(fails: 104 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851c7fcd18483339ef2cbdad5d2f2d9